### PR TITLE
Add sample files for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Resume Matcher
+
+This module scores how well a resume matches a given job description and suggests improvements.
+
+## Installation
+
+Install the required packages:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the matcher from the command line by providing paths to the resume and job description text files:
+
+```bash
+python resume_matcher.py resume.txt jd.txt
+```
+
+Sample resume and job description files (`sample_resume.txt` and `sample_jd.txt`)
+are included for quick testing:
+
+```bash
+python resume_matcher.py sample_resume.txt sample_jd.txt
+```
+
+The output displays a match score (0-100%) and improvement suggestions generated using open-source models.

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,2 @@
+from .resume_matcher import ResumeMatcher
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+sentence-transformers
+transformers
+torch

--- a/resume_matcher.py
+++ b/resume_matcher.py
@@ -1,0 +1,59 @@
+# Resume Matcher Module using open-source ML and LLM models
+
+from typing import Tuple
+
+from sentence_transformers import SentenceTransformer, util
+from transformers import pipeline
+
+
+class ResumeMatcher:
+    """A resume matcher that scores resume relevance and suggests improvements."""
+
+    def __init__(self,
+                 embedding_model: str = "sentence-transformers/paraphrase-MiniLM-L6-v2",
+                 llm_model: str = "google/flan-t5-base") -> None:
+        self.embedder = SentenceTransformer(embedding_model)
+        self.generator = pipeline("text2text-generation", model=llm_model)
+
+    def score_resume(self, resume_text: str, jd_text: str) -> float:
+        """Return a similarity score between resume and job description."""
+        resume_emb = self.embedder.encode(resume_text, convert_to_tensor=True)
+        jd_emb = self.embedder.encode(jd_text, convert_to_tensor=True)
+        score = float(util.cos_sim(resume_emb, jd_emb))
+        # convert cosine similarity (-1 to 1) to percentage (0-100)
+        normalized = (score + 1) / 2 * 100
+        return round(normalized, 2)
+
+    def suggest_improvements(self, resume_text: str, jd_text: str) -> str:
+        """Generate suggestions to improve the resume for the JD."""
+        prompt = (
+            "You are an expert career coach. "
+            "Given the following resume and job description, provide concise bullet "
+            "point suggestions to improve the resume so it matches the job.\n\n"
+            f"RESUME:\n{resume_text}\n\nJOB DESCRIPTION:\n{jd_text}\n\nSuggestions:")
+        result = self.generator(prompt, max_length=256, num_beams=4)
+        return result[0]["generated_text"].strip()
+
+    def match(self, resume_text: str, jd_text: str) -> Tuple[float, str]:
+        """Return the score and improvement suggestions."""
+        score = self.score_resume(resume_text, jd_text)
+        suggestions = self.suggest_improvements(resume_text, jd_text)
+        return score, suggestions
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description="Score a resume against a job description")
+    parser.add_argument("resume", help="Path to the resume text file")
+    parser.add_argument("jd", help="Path to the job description text file")
+    args = parser.parse_args()
+
+    with open(args.resume, "r", encoding="utf-8") as r_file:
+        resume_text = r_file.read()
+    with open(args.jd, "r", encoding="utf-8") as jd_file:
+        jd_text = jd_file.read()
+
+    matcher = ResumeMatcher()
+    score, suggestions = matcher.match(resume_text, jd_text)
+    print(f"Match Score: {score}%")
+    print("Suggestions:\n" + suggestions)

--- a/sample_jd.txt
+++ b/sample_jd.txt
@@ -1,0 +1,3 @@
+We are seeking a senior Python developer to build and maintain machine learning services.
+Responsibilities include designing scalable backend systems, collaborating with data scientists,
+and ensuring reliability of microservices.

--- a/sample_resume.txt
+++ b/sample_resume.txt
@@ -1,0 +1,5 @@
+John Doe
+Experienced software engineer with expertise in Python, machine learning, and system architecture.
+Previously worked at Acme Corp where I developed scalable backend services and optimized data processing pipelines.
+Skills: Python, ML, system design, REST APIs, Docker
+Education: B.Sc in Computer Science


### PR DESCRIPTION
## Summary
- add example resume and job description text files
- document how to run the matcher using the new samples

## Testing
- `python -m py_compile resume_matcher.py`
- `python resume_matcher.py sample_resume.txt sample_jd.txt` *(fails: ModuleNotFoundError: No module named 'sentence_transformers')*

------
https://chatgpt.com/codex/tasks/task_e_685192b1987c832e9d44ed5fec71be52